### PR TITLE
Replacement support in recipient field

### DIFF
--- a/applets/text/twiml.php
+++ b/applets/text/twiml.php
@@ -1,20 +1,23 @@
 <?php
 $ci =& get_instance();
 
-$number = AppletInstance::getValue('number');
-$recipient = normalize_phone_to_E164(AppletInstance::getValue('recipient'));
-$message = AppletInstance::getValue('sms');
-
 if(!empty($_REQUEST['From'])) {
 	$from = normalize_phone_to_E164($_REQUEST['From']);
 	$to = normalize_phone_to_E164($_REQUEST['To']);
+
+    $number = AppletInstance::getValue('number');
+    $recipient = str_replace(array('%caller%', '%number%'), array($from, $to), AppletInstance::getValue('recipient'));
+    $recipient = normalize_phone_to_E164($recipient);
+    $message = AppletInstance::getValue('sms');
+
 	if(AppletInstance::getFlowType() == 'voice')
 		$message = str_replace(array('%caller%', '%number%'), array($from, $to), $message);
 	else
 		$message = str_replace(array('%sender%', '%number%', '%body%'), array($from, $to, $_REQUEST['Body']), $message);
-  require_once(APPPATH . 'libraries/Services/Twilio.php');
-  $service = new Services_Twilio($ci->twilio_sid, $ci->twilio_token);
-  $service->account->sms_messages->create($number, $recipient, $message);
+
+    require_once(APPPATH . 'libraries/Services/Twilio.php');
+    $service = new Services_Twilio($ci->twilio_sid, $ci->twilio_token);
+    $service->account->sms_messages->create($number, $recipient, $message);
 }
 
 $response = new TwimlResponse;


### PR DESCRIPTION
Added support for replacements in 'recipient', allowing
direct SMS to %caller% (as the help text suggests for me).
